### PR TITLE
[Fasterize/FasterizeEngine#874]: Make restart workers more robust

### DIFF
--- a/cluster-master.js
+++ b/cluster-master.js
@@ -1,8 +1,10 @@
 // Set up a cluster and set up resizing and such.
 
 var cluster = require("cluster")
+, _ = require("underscore")
 , quitting = false
 , restarting = false
+, tooQuick = false
 , path = require("path")
 , clusterSize = 0
 , env
@@ -17,10 +19,14 @@ var cluster = require("cluster")
 , unstableRestarts = 0
 , listeningWorkers = true
 , danger = false
+, handleWorkerCondemnedToBeDeadInterval
+, tooQuickTimeOut = 30000
 , logger;
 
 exports = module.exports = clusterMaster
 exports.restart = restart
+exports.disconnectWorker = disconnectWorker
+exports.handleWorkerCondemnedToBeDead = handleWorkerCondemnedToBeDead
 exports.resize = resize
 exports.quitHard = quitHard
 exports.quit = quit
@@ -45,11 +51,22 @@ function debug () {
   })
 }
 
+function disconnectWorker(worker) {
+  worker.willBeDead = true;
+  if (worker.suicide) {
+    worker.process.disconnect();
+  } else {
+    worker.disconnect();
+  }
+}
 
 function clusterMaster (config) {
   if (typeof config === "string") config = { exec: config }
 
   if (config.logger) logger = config.logger;
+
+  // set interval to 30s
+  handleWorkerCondemnedToBeDeadInterval = config.cleanWorkersInterval || 30000
 
   if (!config.exec) {
     throw new Error("Must define a 'exec' script")
@@ -306,20 +323,56 @@ function forkListener () {
   })
 }
 
+function handleWorkerCondemnedToBeDead(workers) {
+  if (!restarting) {
+    debug("handler of worker condemned to be dead is started")
+    Object.keys(workers).forEach( function(key) {
+      if (workers[key].willBeDead == true) {
+        debug("force disconnect worker id:", key)
+        workers[key].process.disconnect()
+      }
+      // delaye the force disconnect for next time for suicide case
+      if (workers[key].suicide == true) {
+        debug("set willBeDead in worker id:", key)
+        workers[key].willBeDead = true
+      }
+    });
+  }
+}
+
+setInterval(function() {
+  handleWorkerCondemnedToBeDead(cluster.workers)
+}, handleWorkerCondemnedToBeDeadInterval);
+
+
 function restart (cb) {
-  if (restarting) {
-    debug("Already restarting.  Cannot restart yet.")
+
+  if (restarting || tooQuick) {
+    debug("Already restarting or too quick restart.  Cannot restart yet.")
     return
   }
 
+  // cleanUp before restarting
+  handleWorkerCondemnedToBeDead(cluster.workers)
+
   restarting = true
+  // prevent too quick reload (30s)
+  tooQuick = true
+  setTimeout(function() {
+    tooQuick = false
+  }, tooQuickTimeOut)
 
   // graceful restart.
   // all the existing workers get killed, and this
   // causes new ones to be spawned.  If there aren't
   // already the intended number, then fork new extras.
-  var current = Object.keys(cluster.workers)
-  , length = current.length
+  // Apply restart only on worker that are not tagged with willBeDead
+  // this will prevent the growth in size when restart is fired
+  var current = _.filter(Object.keys(cluster.workers), function(workerId){
+    return !(cluster.workers[workerId].willBeDead)
+  });
+
+  var length = current.length
   , reqs = clusterSize - length
 
   var i = 0
@@ -353,7 +406,7 @@ function restart (cb) {
 
     if (quitting) {
       if (worker && worker.process.connected) {
-        worker.disconnect()
+        disconnectWorker(worker)
       }
       return graceful()
     }
@@ -364,7 +417,7 @@ function restart (cb) {
         var timer = setTimeout(function () {
           newbie.removeListener('exit', skeptic)
           if (worker && worker.process.connected) {
-            worker.disconnect()
+            disconnectWorker(worker)
           }
           graceful()
         }, 2000)
@@ -385,7 +438,7 @@ function restart (cb) {
     } else {
       function classicRestart(newbie) {
         if (worker && worker.process.connected) {
-          worker.disconnect()
+          disconnectWorker(worker)
         }
       }
 
@@ -482,7 +535,7 @@ function resize (n, cb_) {
     debug('resizing down', current[i])
     worker.once('exit', then())
     if (worker && worker.process.connected) {
-      worker.disconnect()
+      disconnectWorker(worker)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,15 @@
   "engines": {
     "node": ">=0.7.7"
   },
-  "license": "BSD"
+  "license": "BSD",
+  "dependencies": {
+    "underscore": "^1.8.3"
+  },
+  "devDependencies": {
+    "assert": "^1.3.0",
+    "sinon": "^1.17.1"
+  },
+  "scripts": {
+    "test": "mocha ./test/*"
+  }
 }

--- a/test/cluster-master_test.js
+++ b/test/cluster-master_test.js
@@ -1,0 +1,82 @@
+var clusterMaster = require('../cluster-master.js'),
+    sinon = require('sinon'),
+    assert = require('assert');
+
+describe('ClusterMaster', function() {
+
+  describe('Worker actions', function() {
+    var worker;
+    beforeEach(function(){
+      worker = {
+        process:  {disconnect: sinon.spy()},
+        disconnect: sinon.spy()
+      }
+    });
+
+    it("should disconnect worker when suicide not defined", function(){
+      clusterMaster.disconnectWorker(worker);
+
+      assert(worker.disconnect.calledOnce)
+      assert(!worker.process.disconnect.calledOnce)
+      assert(worker.willBeDead)
+    });
+
+    it("should disconnect worker when suicide is true", function(){
+      worker.suicide = true;
+      clusterMaster.disconnectWorker(worker);
+
+      assert(worker.process.disconnect.calledOnce)
+      assert(!worker.disconnect.calledOnce)
+      assert(worker.willBeDead)
+    });
+  });
+
+  describe('handleWorkerCondemnedToBeDead', function() {
+    var workers;
+    beforeEach(function(){
+      workers = {
+        '1': {
+          process: { disconnect: sinon.spy() },
+          disconnect: sinon.spy()
+        },
+        '2': {
+          process: { disconnect: sinon.spy() },
+          disconnect: sinon.spy()
+        },
+        '3': {
+          process: { disconnect: sinon.spy() },
+          disconnect: sinon.spy()
+        }
+      }
+    });
+
+    it("should disconnect worker tagged with the flag willBeDead", function(){
+      workers['1'].willBeDead = true;
+      clusterMaster.handleWorkerCondemnedToBeDead(workers);
+
+      assert(workers['1'].process.disconnect.calledOnce)
+      assert(!workers['2'].process.disconnect.calledOnce)
+      assert(!workers['3'].process.disconnect.calledOnce)
+
+      assert(!workers['1'].disconnect.calledOnce)
+      assert(!workers['2'].disconnect.calledOnce)
+      assert(!workers['3'].disconnect.calledOnce)
+    });
+
+    it("should tag suicide worker with willBeDead", function(){
+      workers['1'].suicide = true;
+      clusterMaster.handleWorkerCondemnedToBeDead(workers);
+
+      assert(workers['1'].willBeDead)
+
+      assert(!workers['1'].process.disconnect.calledOnce)
+      assert(!workers['2'].process.disconnect.calledOnce)
+      assert(!workers['3'].process.disconnect.calledOnce)
+
+      assert(!workers['1'].disconnect.calledOnce)
+      assert(!workers['2'].disconnect.calledOnce)
+      assert(!workers['3'].disconnect.calledOnce)
+    });
+
+  });
+});


### PR DESCRIPTION
- handle the case of worker with `suicide = true`.
- Mark the workers to be terminated and make sure that all of them are terminated.
- prevent too quick reload, fix delay between reloads eql to 30s.
- run at a fixed interval a cleaner of cluster workers:
  - if he found worker with willBeDead => disconnect the workers
  - if he founds worker with suicide eq true => mark it with `willBeDead`
- this commit was inspired by terminator saga.
