### PR TITLE
[fasterize/FasterizeEngine#895] Don't try to disconnect multiple times.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "cluster-master",
+  "version": "0.2.1",
+  "npm-shrinkwrap-version": "5.4.0",
+  "node-version": "v0.12.7",
+  "dependencies": {
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "assert": "^1.3.0",
+    "should": "^7.1.1",
     "sinon": "^1.17.1"
   },
   "scripts": {


### PR DESCRIPTION
- If a worker has its suicide flag set we must not try to disconnect it.
- A worker with a suicide flag or in disconnected state should be kill.
- We must not roughly kill a worker if the forcefully kill tentative has
  not occur.
- Harmonize the test framework with the engine.
- Rebase on latest upstream version.
